### PR TITLE
メモ一覧機能のルーティングとコントローラーの実装

### DIFF
--- a/app/assets/stylesheets/api/memos.scss
+++ b/app/assets/stylesheets/api/memos.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the api/memos controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/api/memos_controller.rb
+++ b/app/controllers/api/memos_controller.rb
@@ -1,0 +1,2 @@
+class Api::MemosController < ApplicationController
+end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,5 @@
 class HomeController < ApplicationController
   def index
+    @memos = Memo.order('created_at DESC')
   end
 end

--- a/app/helpers/api/memos_helper.rb
+++ b/app/helpers/api/memos_helper.rb
@@ -1,0 +1,2 @@
+module Api::MemosHelper
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
   get 'home', to: 'home#index'
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+
+  namespace :api, format: 'json' do
+    resources :memos, only: [:index]
+  end
 end

--- a/test/controllers/api/memos_controller_test.rb
+++ b/test/controllers/api/memos_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Api::MemosControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
namespace :api, format: 'json' do
  resources :memos, only: [:index]
end

namespace を使っている背景としては、URLやファイル構成を指定のパスにしたいため。指定のパスにすることで今後の管理が容易になる。
format: 'json' というコードでJSON形式に指定。